### PR TITLE
为`/spectator teleport`添加`location`选项

### DIFF
--- a/docs/commands/spectator.md
+++ b/docs/commands/spectator.md
@@ -11,6 +11,8 @@
     - 如果在主世界和下界直接传送并且未指定位置，则会自动换算坐标
 - `spectator teleport entity <entity>`：将自己传送至指定实体位置
     - 自己必须处于旁观模式
+- `spectator teleport location <location>`：将自己传送至指定位置
+    - 自己必须处于旁观模式
 
 ## 示例
 

--- a/src/main/java/boat/carpetorgaddition/CarpetOrgAddition.java
+++ b/src/main/java/boat/carpetorgaddition/CarpetOrgAddition.java
@@ -69,16 +69,16 @@ public class CarpetOrgAddition implements ModInitializer {
      */
     public static final boolean CARPET_TIS_ADDITION = FabricLoader.getInstance().isModLoaded("carpet-tis-addition");
     /**
+     * 日志
+     */
+    public static final Logger LOGGER = LoggerFactory.getLogger(COMPACT_MOD_NAME);
+    /**
      * 是否启用隐藏功能<br>
      * <p>
      * <b>请勿</b>传播解锁这些功能的方式。
      * </p>
      */
     public static final boolean ENABLE_HIDDEN_FUNCTION = GlobalConfigs.getInstance().isEnableHiddenFunction();
-    /**
-     * 日志
-     */
-    public static final Logger LOGGER = LoggerFactory.getLogger(COMPACT_MOD_NAME);
 
     /**
      * 模组初始化

--- a/src/main/java/boat/carpetorgaddition/command/SpectatorCommand.java
+++ b/src/main/java/boat/carpetorgaddition/command/SpectatorCommand.java
@@ -60,7 +60,10 @@ public class SpectatorCommand extends AbstractServerCommand {
                                                 .executes(this::tpToDimensionLocation))))
                         .then(Commands.literal("entity")
                                 .then(Commands.argument("entity", EntityArgument.entity())
-                                        .executes(this::tpToEntity)))));
+                                        .executes(this::tpToEntity)))
+                        .then(Commands.literal("location")
+                                .then(Commands.argument("location", Vec3Argument.vec3())
+                                        .executes(this::tpToLocation)))));
     }
 
     // 更改游戏模式
@@ -144,6 +147,26 @@ public class SpectatorCommand extends AbstractServerCommand {
                 LocalizationKey.literal("commands.teleport.success.entity.single").translate(
                         player.getDisplayName(),
                         entity.getDisplayName()
+                )
+        );
+        return 1;
+    }
+
+    // 传送到指定坐标
+    private int tpToLocation(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
+        ServerPlayer player = CommandUtils.getSourcePlayer(context);
+        // 检查玩家是不是旁观模式
+        requireSpectator(player);
+        Vec3 location = Vec3Argument.getVec3(context, "location");
+        ServerUtils.teleport(player, player.level(), location.x(), location.y(), location.z(), player.getYRot(), player.getXRot());
+        // 发送命令反馈
+        MessageUtils.sendMessage(
+                context,
+                LocalizationKey.literal("commands.teleport.success.location.single").translate(
+                        player.getDisplayName(),
+                        formatFloat(location.x()),
+                        formatFloat(location.y()),
+                        formatFloat(location.z())
                 )
         );
         return 1;


### PR DESCRIPTION
通过`/spectator teleport location <location>`, 无需显式设定维度

便于在Xaero系列地图mod设定传送命令

<img width="1201" height="753" alt="Screen Shot 2026-02-13 at 23 22 20" src="https://github.com/user-attachments/assets/be029f2d-1512-4c2c-a557-a75a488bff61" />
